### PR TITLE
Create footprint service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 /coverage
 
 .DS_Store
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ end
 group :test do
   gem 'shoulda-matchers', '~> 4.0'
   gem 'simplecov'
+  gem 'webmock'
+  gem 'vcr'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     diff-lcs (1.4.4)
     docile (1.3.4)
@@ -79,6 +81,7 @@ GEM
       railties
       sprockets-rails
     graphql (1.11.6)
+    hashdiff (1.0.1)
     highline (2.0.3)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
@@ -152,6 +155,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rexml (3.2.4)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -198,6 +202,11 @@ GEM
       pusher-client (~> 0.4)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
+    vcr (6.0.0)
+    webmock (3.11.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.9)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
@@ -222,6 +231,8 @@ DEPENDENCIES
   simplecov
   travis
   tzinfo-data
+  vcr
+  webmock
 
 RUBY VERSION
    ruby 2.5.3p105

--- a/app/facades/footprint_facade.rb
+++ b/app/facades/footprint_facade.rb
@@ -1,0 +1,12 @@
+class FootprintFacade
+  class << self
+    def create_footprint(car, mileage)
+      response = FootprintService.vehicle_footprint(car, mileage)[:data]
+      Footprint.create(
+        carbon_in_kg: response[:equivalent_carbon_in_kg],
+        offset_cost_total: response[:cloverly_offset_cost][:total],
+        offset_cost_currency: response[:cloverly_offset_cost][:currency]
+      )
+    end
+  end
+end

--- a/app/services/footprint_service.rb
+++ b/app/services/footprint_service.rb
@@ -8,7 +8,7 @@ class FootprintService
     private
 
     def conn
-      Faraday.new(url: ENV['MICROSERVICE_URL'])
+      Faraday.new(url: 'https://cloverly-microservice.herokuapp.com')
     end
   end
 end

--- a/app/services/footprint_service.rb
+++ b/app/services/footprint_service.rb
@@ -1,0 +1,14 @@
+class FootprintService
+  class << self
+    def vehicle_footprint(car, mileage)
+      response = conn.get("/api/v1/carbonfootprint?fuel_efficiency=#{car.mpg}&trip_distance=#{mileage}&fuel_type=#{car.fuel_type}")
+      JSON.parse(response.body, symbolize_names: true)
+    end
+
+    private
+
+    def conn
+      Faraday.new(url: ENV['MICROSERVICE_URL'])
+    end
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,4 +82,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Do not fall back to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
 end

--- a/spec/facades/footprint_facade_spec.rb
+++ b/spec/facades/footprint_facade_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'Footprint Facade' do
+  it 'creates a footprint' do
+    VCR.use_cassette('vehicle_footprint_request') do
+      car = Car.create!(
+        user_id: 1,
+        make: 'Nissan',
+        model: 'Frontier',
+        year: '2003',
+        mpg: 22,
+        fuel_type: 'gasoline'
+      )
+      mileage = 9001
+
+      footprint = FootprintFacade.create_footprint(car, mileage)
+
+      expect(footprint).to be_a(Footprint)
+      expect(footprint.carbon_in_kg).to be_a(Float)
+      expect(footprint.offset_cost_total).to be_a(Float)
+      expect(footprint.offset_cost_currency).to be_a(String)
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/vehicle_footprint_request.yml
+++ b/spec/fixtures/vcr_cassettes/vehicle_footprint_request.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:4567/api/v1/carbonfootprint?fuel_efficiency=22&fuel_type=gasoline&trip_distance=9001
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.3.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '100'
+      X-Content-Type-Options:
+      - nosniff
+      Connection:
+      - keep-alive
+      Server:
+      - thin
+    body:
+      encoding: UTF-8
+      string: '{"data":{"equivalent_carbon_in_kg":3636.787,"cloverly_offset_cost":{"currency":"USD","total":8.27}}}'
+  recorded_at: Sat, 09 Jan 2021 20:35:38 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/vehicle_footprint_request.yml
+++ b/spec/fixtures/vcr_cassettes/vehicle_footprint_request.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:4567/api/v1/carbonfootprint?fuel_efficiency=22&fuel_type=gasoline&trip_distance=9001
+    uri: https://cloverly-microservice.herokuapp.com/api/v1/carbonfootprint?fuel_efficiency=22&fuel_type=gasoline&trip_distance=9001
     body:
       encoding: US-ASCII
       string: ''
@@ -16,20 +16,24 @@ http_interactions:
   response:
     status:
       code: 200
-      message: OK
+      message: 'OK '
     headers:
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json
       Content-Length:
       - '100'
       X-Content-Type-Options:
       - nosniff
-      Connection:
-      - keep-alive
       Server:
-      - thin
+      - WEBrick/1.4.2 (Ruby/2.5.3/2018-10-18)
+      Date:
+      - Sun, 10 Jan 2021 03:07:44 GMT
+      Via:
+      - 1.1 vegur
     body:
       encoding: UTF-8
       string: '{"data":{"equivalent_carbon_in_kg":3636.787,"cloverly_offset_cost":{"currency":"USD","total":8.27}}}'
-  recorded_at: Sat, 09 Jan 2021 20:35:38 GMT
+  recorded_at: Sun, 10 Jan 2021 03:07:44 GMT
 recorded_with: VCR 6.0.0

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,3 +71,9 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+  config.default_cassette_options = { re_record_interval: 30.days }
+end

--- a/spec/services/footprint_service_spec.rb
+++ b/spec/services/footprint_service_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'Footprint Service' do
+  it 'can get cloverly response' do
+    VCR.use_cassette('vehicle_footprint_request', record: :new_episodes) do
+      car = Car.create!(
+        user_id: 1,
+        make: 'Nissan',
+        model: 'Frontier',
+        year: '2003',
+        mpg: 22,
+        fuel_type: 'gasoline'
+      )
+      data = FootprintService.vehicle_footprint(car, 9001)
+
+      expect(data).to be_a(Hash)
+      expect(data).to have_key(:data)
+
+      expect(data[:data]).to have_key(:equivalent_carbon_in_kg)
+      expect(data[:data][:equivalent_carbon_in_kg]).to be_a(Float)
+
+      expect(data[:data]).to have_key(:cloverly_offset_cost)
+      expect(data[:data][:cloverly_offset_cost]).to have_key(:currency)
+      expect(data[:data][:cloverly_offset_cost][:currency]).to be_a(String)
+      expect(data[:data][:cloverly_offset_cost]).to have_key(:total)
+      expect(data[:data][:cloverly_offset_cost][:total]).to be_a(Float)
+    end
+  end
+end


### PR DESCRIPTION
Builds out service and facade for footprints.

## Description
- Consumes the carbonfootprint endpoint from the Cloverly-Microservice
- Facade saves footprint to the database
- closes #17
- closes #11
- Disabled asset compilation in production environment (`config/environment/production.rb`)

## Motivation and Context
This enables all functionality around footprints to be built out.

## How Has This Been Tested?
Tested the structure of microservice return data, and the ability of the facade to create footprint objects from that data. VCR was also added and enabled to mock out the microservice request.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have updated the README to reflect any changes.
