### PR TITLE
Single CarMonthlyMileage query

### DIFF
--- a/app/graphql/types/car_monthly_mileage.rb
+++ b/app/graphql/types/car_monthly_mileage.rb
@@ -5,7 +5,7 @@ module Types
     field :footprint_id, Integer, null: true
     field :total_mileage, Integer, null: true
     field :month, String, null: true
-    field :year, String, null: true
+    field :year, Integer, null: true
     field :footprint, Types::FootprintType, null: true
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -15,8 +15,18 @@ module Types
       Car.find(id)
     end
 
+    field :car_monthly_mileage, Types::CarMonthlyMileage, null: false do
+      argument :id, ID, required: true
+    end
+
+    def car_monthly_mileage(id:)
+      ::CarMonthlyMileage.find(id)
+    end
+
     field :fetch_user_cars, resolver: Queries::FetchUserCars
     field :fetch_user_car_month_footprint, resolver: Queries::FetchUserCarMonthFootprint
     field :fetch_user_aggregate_footprint_for_year, resolver: Queries::FetchUserAggregateFootprintForYear
+
+
   end
 end

--- a/spec/requests/graphql/car_monthly_mileage_request_spec.rb
+++ b/spec/requests/graphql/car_monthly_mileage_request_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe 'CarMonthlyMileageQuery' do
+  before :each do
+    @car = Car.create(
+      id: 5,
+      user_id: 1,
+      make: "Chevy",
+      model: 'Cobalt',
+      year: 2006,
+      mpg: 25,
+      fuel_type: 'gasoline'
+    )
+
+    @footprint = Footprint.create(
+      id: 5,
+      carbon_in_kg: 12444.511,
+      offset_cost_total: 28.14,
+      offset_cost_currency: 'USD'
+    )
+
+    @cmm1 = CarMonthlyMileage.create(
+      car_id: 5,
+      footprint_id: 5,
+      total_mileage: 35000,
+      month: "March",
+      year: 2011
+    )
+  end
+
+  it 'can get a single CarMonthlyMileage with id as input' do
+    query_string = <<-GRAPHQL
+      query {
+        carMonthlyMileage(id: #{@cmm1.id}) {
+          id
+          month
+          year
+          totalMileage
+        }
+      }
+    GRAPHQL
+
+
+    post graphql_path, params: { query: query_string }
+    result = JSON.parse(response.body, symbolize_names: true)
+    expect(result[:data][:carMonthlyMileage][:id]).to eq("#{@cmm1.id}")
+    expect(result[:data][:carMonthlyMileage][:month]).to eq(@cmm1.month)
+    expect(result[:data][:carMonthlyMileage][:year]).to eq(@cmm1.year)
+    expect(result[:data][:carMonthlyMileage][:totalMileage]).to eq(@cmm1.total_mileage)
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A super quick and dirty query to get a single CarMonthlyMileage using it's id; should make it easier to get for the update page in the front end

## Description
<!--- Describe your changes in detail -->
Added `field :car_monthly_mileage` and resolving method directly into  Types::QueryType; may want to refactor it into a unique query at some point

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes it much easier to return this data in both the front and back end; uses the id, so can grab that resource directly without any `.where` clauses

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Same test setup as most of the other query tests; expects that a response returns a specific object.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the README to reflect any changes.
