### PR TITLE
Revise car monthly mileage

### DIFF
--- a/app/graphql/mutations/update_car_monthly_mileage.rb
+++ b/app/graphql/mutations/update_car_monthly_mileage.rb
@@ -3,13 +3,12 @@ module Mutations
     description "Update monthly milagemand footprint for car"
 
     argument :total_mileage, Integer, required: true
-    argument :id, Integer, required: true
+    argument :car_monthly_mileage_id, Integer, required: true
 
     field :footprint, Types::FootprintType, null: true
 
     def resolve(args)
-
-      car_monthly_mileage = CarMonthlyMileage.find(args[:id])
+      car_monthly_mileage = CarMonthlyMileage.find(args[:car_monthly_mileage_id])
 
       car_monthly_mileage.update(total_mileage: args[:total_mileage])
 

--- a/app/graphql/mutations/update_car_monthly_mileage.rb
+++ b/app/graphql/mutations/update_car_monthly_mileage.rb
@@ -3,17 +3,13 @@ module Mutations
     description "Update monthly milagemand footprint for car"
 
     argument :total_mileage, Integer, required: true
-    argument :car_id, Integer, required: true
-    argument :month, String, required: true
-    argument :year, String, required: true
+    argument :id, Integer, required: true
 
     field :footprint, Types::FootprintType, null: true
 
     def resolve(args)
 
-      car = Car.find(args[:car_id])
-
-      car_monthly_mileage = CarMonthlyMileage.find_by(car_id: car.id, month: args[:month], year: args[:year])
+      car_monthly_mileage = CarMonthlyMileage.find(args[:id])
 
       car_monthly_mileage.update(total_mileage: args[:total_mileage])
 

--- a/spec/requests/graphql/aggregate_footprint_for_year_spec.rb
+++ b/spec/requests/graphql/aggregate_footprint_for_year_spec.rb
@@ -78,7 +78,7 @@ describe 'Fetch aggregate footprint query for year' do
 
     post graphql_path, params: { query: query_string}
     result = JSON.parse(response.body, symbolize_names: true)
-    
+
     expect(result[:data].class).to eq(Hash)
     expect(result[:data][:fetchUserAggregateFootprintForYear].class).to eq(Hash)
     expect(result[:data][:fetchUserAggregateFootprintForYear][:footprints].class).to eq(Array)

--- a/spec/requests/graphql/update_carbon_footprint_spec.rb
+++ b/spec/requests/graphql/update_carbon_footprint_spec.rb
@@ -15,10 +15,8 @@ describe "As a User " do
     query_string = <<-GRAPHQL
     mutation {
       updateCarMonthlyMileage(input:{
-        carId: #{@car.id},
-        totalMileage: 22,
-        month: "#{@cmm.month}",
-        year: "2011"
+        id: #{@cmm.id},
+        totalMileage: 22
     }) {
       footprint {
         carbonInKg
@@ -30,7 +28,6 @@ describe "As a User " do
     GRAPHQL
 
     post graphql_path, params: {query: query_string}
-    result = JSON.parse(response.body,)
 
     @cmm.reload
     expect(@cmm.total_mileage).to_not eq(35000)

--- a/spec/requests/graphql/update_carbon_footprint_spec.rb
+++ b/spec/requests/graphql/update_carbon_footprint_spec.rb
@@ -15,7 +15,7 @@ describe "As a User " do
     query_string = <<-GRAPHQL
     mutation {
       updateCarMonthlyMileage(input:{
-        id: #{@cmm.id},
+        carMonthlyMileageId: #{@cmm.id},
         totalMileage: 22
     }) {
       footprint {
@@ -28,7 +28,7 @@ describe "As a User " do
     GRAPHQL
 
     post graphql_path, params: {query: query_string}
-
+    
     @cmm.reload
     expect(@cmm.total_mileage).to_not eq(35000)
     expect(@cmm.total_mileage).to eq(22)


### PR DESCRIPTION
Revision of CarMonthlyMileage mutation

## Description
Changed the arguments needed in the mutation:
- Removed month and year
- Added car_monthly_mileages_id
- The mutation now accepts carMonthlyMileageId as an input variable
- Changed the find_by to a find(args[i:d])
Closes #33

## Motivation and Context
Since CarMonthlymileage can now be gotten from the front end edit page the mutation now accepts the CarMonthlyMilage id as an argument and the month and year are no longer needed.

## How Has This Been Tested?
The tests already there were left unchanged but the query string was changed to reflect the changes to what the input is.
The test makes the mutation call and checks for the change in the total_mileage and that the footprint gets updated accordingly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the README to reflect any changes.
