### PR TITLE
Update car monthly mileage

### DIFF
--- a/app/graphql/mutations/update_car_monthly_mileage.rb
+++ b/app/graphql/mutations/update_car_monthly_mileage.rb
@@ -3,17 +3,14 @@ module Mutations
     description "Update monthly milagemand footprint for car"
 
     argument :total_mileage, Integer, required: true
-    argument :car_id, Integer, required: true
+    argument :id, Integer, required: true
     argument :month, String, required: true
     argument :year, String, required: true
 
     field :footprint, Types::FootprintType, null: true
 
     def resolve(args)
-
-      car = Car.find(args[:car_id])
-
-      car_monthly_mileage = CarMonthlyMileage.find_by(car_id: car.id, month: args[:month], year: args[:year])
+      car_monthly_mileage = CarMonthlyMileage.find(args[:id])
 
       car_monthly_mileage.update(total_mileage: args[:total_mileage])
 

--- a/app/graphql/mutations/update_car_monthly_mileage.rb
+++ b/app/graphql/mutations/update_car_monthly_mileage.rb
@@ -5,7 +5,7 @@ module Mutations
     argument :total_mileage, Integer, required: true
     argument :id, Integer, required: true
     argument :month, String, required: true
-    argument :year, String, required: true
+    argument :year, Integer, required: true
 
     field :footprint, Types::FootprintType, null: true
 

--- a/spec/requests/graphql/update_carbon_footprint_spec.rb
+++ b/spec/requests/graphql/update_carbon_footprint_spec.rb
@@ -6,7 +6,7 @@ describe 'As a User ' do
 
     @foot = Footprint.create(id: 5, carbon_in_kg: 12_444.511, offset_cost_total: 28.14, offset_cost_currency: 'USD')
 
-    @cmm = CarMonthlyMileage.create(car_id: 5, footprint_id: 5, total_mileage: 35_000, month: 'March', year: '2011')
+    @cmm = CarMonthlyMileage.create(car_id: 5, footprint_id: 5, total_mileage: 35_000, month: 'March', year: 2011)
   end
 
   it 'can update their carbon footprint', :vcr do
@@ -16,7 +16,7 @@ describe 'As a User ' do
         id: #{@cmm.id},
         totalMileage: 22,
         month: "#{@cmm.month}",
-        year: "2011"
+        year: 2011
     }) {
       footprint {
         carbonInKg

--- a/spec/requests/graphql/update_carbon_footprint_spec.rb
+++ b/spec/requests/graphql/update_carbon_footprint_spec.rb
@@ -15,7 +15,7 @@ describe "As a User " do
     query_string = <<-GRAPHQL
     mutation {
       updateCarMonthlyMileage(input:{
-        carId: #{@car.id},
+        id: #{@cmm.id},
         totalMileage: 22,
         month: "#{@cmm.month}",
         year: "2011"

--- a/spec/requests/graphql/update_carbon_footprint_spec.rb
+++ b/spec/requests/graphql/update_carbon_footprint_spec.rb
@@ -1,17 +1,15 @@
 require 'rails_helper'
 
-describe "As a User " do
+describe 'As a User ' do
   before :each do
-    @car = Car.create(id: 5, user_id: 1, make: "Chevy", model: 'Cobalt', year: 2006, mpg: 25, fuel_type: 'gasoline')
+    @car = Car.create(id: 5, user_id: 1, make: 'Chevy', model: 'Cobalt', year: 2006, mpg: 25, fuel_type: 'gasoline')
 
-    @foot = Footprint.create(id: 5, carbon_in_kg: 12444.511, offset_cost_total: 28.14, offset_cost_currency: 'USD')
+    @foot = Footprint.create(id: 5, carbon_in_kg: 12_444.511, offset_cost_total: 28.14, offset_cost_currency: 'USD')
 
-    @cmm = CarMonthlyMileage.create(car_id: 5, footprint_id: 5, total_mileage: 35000, month: "March", year: "2011")
-
-
+    @cmm = CarMonthlyMileage.create(car_id: 5, footprint_id: 5, total_mileage: 35_000, month: 'March', year: '2011')
   end
 
-  it "can update their carbon footprint", :vcr do
+  it 'can update their carbon footprint', :vcr do
     query_string = <<-GRAPHQL
     mutation {
       updateCarMonthlyMileage(input:{
@@ -29,19 +27,17 @@ describe "As a User " do
   }
     GRAPHQL
 
-    post graphql_path, params: {query: query_string}
-    result = JSON.parse(response.body,)
+    post graphql_path, params: { query: query_string }
+    result = JSON.parse(response.body)
 
     @cmm.reload
-    expect(@cmm.total_mileage).to_not eq(35000)
+    expect(@cmm.total_mileage).to_not eq(35_000)
     expect(@cmm.total_mileage).to eq(22)
 
     @foot.reload
-    expect(@foot.carbon_in_kg).to_not eq(12444.511)
+    expect(@foot.carbon_in_kg).to_not eq(12_444.511)
     expect(@foot.carbon_in_kg).to eq(7.822)
     expect(@foot.offset_cost_total).to_not eq(28.14)
     expect(@foot.offset_cost_total).to eq(0.27)
-
-
   end
 end


### PR DESCRIPTION
## Description
Changed year data type to integer on the update_car_monthly_mileage mutation
CHange the argument on the update car monthly mileage mutation to include its id instead of the car id.  When the front end fetches car monthly mileages from the backend no car id is given so there is no way for the front end to return a car id to the backend when update.  This can just be done with the car_monthly_mileage id.

## How Has This Been Tested?
All tests passing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the README to reflect any changes.
